### PR TITLE
Kafka: Replace deprecated base image

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,5 +1,4 @@
-
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV kafka_version=0.10.1.1
 ENV scala_version=2.11.8


### PR DESCRIPTION
According to [java](https://hub.docker.com/_/java/), the base image is deprecated and won't receive further updates. Replaced it with the official [openjdk](https://hub.docker.com/_/openjdk/) image.