### PR TITLE
No longer start any service by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,36 @@
-# dockerfiles
+# Kafka docker builds
 
-Nowadays we're using separate repositories for dockerization projects.
+Automated [Kafka](http://kafka.apache.org/) builds for https://hub.docker.com/r/solsson/kafka/
+and related `kafka-` images under https://hub.docker.com/u/solsson/.
+
+---
+
+This repo used to contain misc dockerfiles, but they've moved to separate repositories for dockerization projects.
+We've kept the repository name to avoid breaking the automated build of solsson/kafka in Docker Hub.
 
 For legacy Dockerfiles from this repo (if you navigated to here from a Docker Hub [solsson](https://hub.docker.com/u/solsson/) image),
 see https://github.com/solsson/dockerfiles/tree/misc-dockerfiles.
 
-# Kafka docker builds
+---
 
-This repository maintains automated [Kafka](http://kafka.apache.org/) builds for https://hub.docker.com/r/solsson/kafka/
-and related `kafka-` images under https://hub.docker.com/u/solsson/.
+Our kafka images are tested in production with https://github.com/Yolean/kubernetes-kafka/.
 
-These images are tested in production with https://github.com/Yolean/kubernetes-kafka/.
+You most likely need to mount your own config files, or for `./bin/kafka-server-start.sh` use overrides like:
+```
+  --override zookeeper.connect=zookeeper:2181
+  --override log.dirs=/var/lib/kafka/data/topics
+  --override log.retention.hours=-1
+  --override broker.id=0
+  --override advertised.listener=PLAINTEXT://kafka-0:9092
+```
 
 ## One image to rule them all
 
 Official [Kafka distributions](http://kafka.apache.org/downloads) contain startup scripts and config for various services and clients. Thus `./kafka` produces a multi-purpose image for direct use and specialized docker builds.
+
+We could build specialized images like `kafka-server` but we have two reasons not to:
+ * Won't be as transparent in Docker Hub because you can't use Automated Build without scripting.
+ * In reality you'll need to control your own config anyway.
 
 ### Example of downstream image: Kafka Connect
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kafka docker builds
 
-Automated [Kafka](http://kafka.apache.org/) builds for https://hub.docker.com/r/solsson/kafka/
+Automated [Kafka](http://kafka.apache.org/) builds for [solsson/kafka](https://hub.docker.com/r/solsson/kafka/)
 and related `kafka-` images under https://hub.docker.com/u/solsson/.
 
 ---
@@ -44,11 +44,7 @@ TODO
 
 Rudimentary compliance with kubernetes-kafka is tested using a [build-contract](https://github.com/Yolean/build-contract/).
 
-Build and test using: `docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/:/source solsson/build-contract test`
-
-To keep kafka running for local use, uncomment `ports` 9092 and run: `docker-compose -f build-contracts/docker-compose.yml up --force-recreate`.
-
-While timing issues remain, start services individually...
+Build and test using: `docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/:/source solsson/build-contract test`. However... while timing issues remain you need some manual intervention:
 
 ```bash
 compose='docker-compose -f build-contracts/docker-compose.yml'

--- a/build-contracts/docker-compose.files-aggregation.yml
+++ b/build-contracts/docker-compose.files-aggregation.yml
@@ -11,8 +11,11 @@ services:
     build: ../kafka
     links:
       - zookeeper
+    entrypoint: ./bin/bin/kafka-server-start.sh
     command:
       - config/server.properties
+      - --override
+      -   zookeeper.connect=zookeeper:2181
       - --override
       -   broker.id=0
       - --override

--- a/build-contracts/docker-compose.monitoring.yml
+++ b/build-contracts/docker-compose.monitoring.yml
@@ -15,8 +15,11 @@ services:
       - JMX_PORT=5555
     expose:
       - '5555'
+    entrypoint: ./bin/bin/kafka-server-start.sh
     command:
       - config/server.properties
+      - --override
+      -   zookeeper.connect=zookeeper:2181
       - --override
       -   broker.id=0
       - --override

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -14,8 +14,11 @@ services:
       com.yolean.build-target: ""
     links:
       - zookeeper
+    entrypoint: ./bin/kafka-server-start.sh
     command:
       - config/server.properties
+      - --override
+      -   zookeeper.connect=zookeeper:2181
       - --override
       -   broker.id=0
       # unlike Kubernetes StatefulSet, compose gives containers a random hostname (leading to redirects to a hex name)

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -19,7 +19,6 @@ RUN set -ex; \
   rm /var/log/dpkg.log /var/log/apt/*.log
 
 WORKDIR /opt/kafka
-ENTRYPOINT ["bin/kafka-server-start.sh"]
 
-RUN sed -i 's/zookeeper.connect=localhost:2181/zookeeper.connect=zookeeper:2181/' config/server.properties
-CMD ["config/server.properties"]
+COPY docker-help.sh /usr/local/bin/docker-help
+ENTRYPOINT ["docker-help"]

--- a/kafka/docker-help.sh
+++ b/kafka/docker-help.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "Hi,"
+echo ""
+echo "This image is basically just the official Kafka distribution,"
+echo "containing both servers and utils, each with its own help output."
+echo ""
+echo "Select as entrypoint one of these scripts:"
+find ./bin/ -name *.sh
+echo ""
+echo "You might find one of the sample config files useful:"
+find ./config/ -name *.properties
+echo ""
+echo "Add more using volumes, or downstream images."
+echo "Enjoy Kafka!"
+echo ""


### PR DESCRIPTION
Motivation:
 * This is how the Kafka distribution works.
 * You'll likely want at least Zookeeper and Kafka to run from this image, so setting an entrypoint for both is more consistent.
 * Once #5 is merged to master and built as `solsson/kafka`, environments that did the 100k pull so far might break, and I prefer them to not start, compared to for example silently reverting config. 

Motivation for avoiding all config overrides:
 * Support drop-in replacement of alternatives to my builds, for example `cp-kafka` or https://github.com/kubernetes/contrib/tree/master/statefulsets/kafka. Of course this depends on how you've configured your services, but it's a noble thought :)