### PR TITLE
Start scripts without ./bin and .sh, config mount at /etc/kafka

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -21,5 +21,13 @@ RUN set -ex; \
 
 WORKDIR /opt/kafka
 
+RUN set -ex; \
+  \
+  bash -ec 'for F in /opt/kafka/bin/*.sh; do ln -sv $F /usr/local/bin/${F:15:-3}; done;' \
+  rm /usr/local/bin/kafka-run-class; \
+  sed -i 's|exec $(dirname $0)/kafka-run-class.sh |exec /opt/kafka/bin/kafka-run-class.sh |' /usr/local/bin/*; \
+  \
+  echo "TODO how do we handle log4j.properties"
+
 COPY docker-help.sh /usr/local/bin/docker-help
 ENTRYPOINT ["docker-help"]

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -23,11 +23,13 @@ WORKDIR /opt/kafka
 
 RUN set -ex; \
   \
-  bash -ec 'for F in /opt/kafka/bin/*.sh; do ln -sv $F /usr/local/bin/${F:15:-3}; done;' \
+  bash -ec 'for F in /opt/kafka/bin/*.sh; do cp -v $F /usr/local/bin/${F:15:-3}; done;' \
   rm /usr/local/bin/kafka-run-class; \
   sed -i 's|exec $(dirname $0)/kafka-run-class.sh |exec /opt/kafka/bin/kafka-run-class.sh |' /usr/local/bin/*; \
+  sed -i 's|base_dir=$(dirname $0)|base_dir=/opt/kafka/bin|' /usr/local/bin/*; \
   \
-  echo "TODO how do we handle log4j.properties"
+  echo "TODO how do we handle log4j.properties"; \
+  grep 'Dlog4j.configuration' /usr/local/bin/* /opt/kafka/bin/kafka-run-class.sh
 
 COPY docker-help.sh /usr/local/bin/docker-help
 ENTRYPOINT ["docker-help"]

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -29,7 +29,10 @@ RUN set -ex; \
   sed -i 's|base_dir=$(dirname $0)|base_dir=/opt/kafka/bin|' /usr/local/bin/*; \
   \
   mv -v ./config /etc/kafka; \
-  ln -sv /etc/kafka ./config;
+  ln -sv /etc/kafka ./config; \
+  \
+  grep 'Dlog4j.configuration' /usr/local/bin/* /opt/kafka/bin/kafka-run-class.sh;
+
 
 COPY docker-help.sh /usr/local/bin/docker-help
 ENTRYPOINT ["docker-help"]

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -28,8 +28,8 @@ RUN set -ex; \
   sed -i 's|exec $(dirname $0)/kafka-run-class.sh |exec /opt/kafka/bin/kafka-run-class.sh |' /usr/local/bin/*; \
   sed -i 's|base_dir=$(dirname $0)|base_dir=/opt/kafka/bin|' /usr/local/bin/*; \
   \
-  echo "TODO how do we handle log4j.properties"; \
-  grep 'Dlog4j.configuration' /usr/local/bin/* /opt/kafka/bin/kafka-run-class.sh
+  mv -v ./config /etc/kafka; \
+  ln -sv /etc/kafka ./config;
 
 COPY docker-help.sh /usr/local/bin/docker-help
 ENTRYPOINT ["docker-help"]


### PR DESCRIPTION
This is inspired by the Confluent Platform images. Without this change, users of the image would settle for the `./bin` and `./config` conventions. Mounted config would sit at /opt/kafka/config or chose a path such as `/etc/kafka` AND set `KAFKA_LOG4J_OPTS` to for example `-D/etc/kafka/log4j.properties`.

This fix will not use any additional space if we restore the symlinks from before 72b35da and move the RUN into the kafka installation step.