### PR TITLE
Document image SHAs, avoid build duplication

### DIFF
--- a/tags/0.10.0.1/Dockerfile
+++ b/tags/0.10.0.1/Dockerfile
@@ -1,0 +1,1 @@
+FROM solsson/kafka:0.10.0.1@sha256:301b1ca59d62e5cb9c030513ac30ebe6c4c020546611e265dd282380b42be6ee

--- a/tags/0.10.2.0-alpine/Dockerfile
+++ b/tags/0.10.2.0-alpine/Dockerfile
@@ -1,0 +1,1 @@
+FROM solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756

--- a/tags/0.11.0.0-alpine/Dockerfile
+++ b/tags/0.11.0.0-alpine/Dockerfile
@@ -1,0 +1,1 @@
+FROM solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756

--- a/tags/0.11.0.0/Dockerfile
+++ b/tags/0.11.0.0/Dockerfile
@@ -1,0 +1,1 @@
+FROM solsson/kafka@sha256:75ecbf6c7fb9f814a0ab0e44c5d48d3cb4dd688a244a377f6986eefcb1498614


### PR DESCRIPTION
Docker's tagging conventions are hard to use. In particular it's difficult to trace a `@sha256:` back to the build and thus the source revision. But you do want the checksums because:
 * You typically have little control over when your environments pull. For example Kubernetes will by default reuse images, but if you add a node it will pull a fresh one.
 * A mistake or attack may re-build the tag with modifications and thereby inflict pain.

In addition, with this repo relying on Docker Hub's automated build feature, each tagged build will be a duplicate of the concurrent `:latest` (different checksums, identical behavior).

You can get reasonable transparency with for example `solsson/kafka:0.11.0.0@sha256:e09d493ae027bbe45d82dc5b9ceaae40adad23efb2936116b233b7dce48136ba` but the problem is that such image identification isn't explicitly supported by Docker. If the tag is re-built (which is legit, and even implied in case of tags like `0.11.0`) you'll get "manifest verification failed" at next pull. You could be forgiven for thinking that Docker would continue to use the old pull, but for that you have to omit the tag. While `solsson/kafka@sha256:e09d493ae027bbe45d82dc5b9ceaae40adad23efb2936116b233b7dce48136ba` is stable over time, your colleague has little chance of knowing which Kafka version you intend to run.