### PR TITLE
Add image for selected Confluent Platform open source services

### DIFF
--- a/cp/Dockerfile
+++ b/cp/Dockerfile
@@ -53,5 +53,5 @@ RUN set -ex; \
   rm -rf /var/lib/apt/lists/*; \
   rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt
 
-COPY docker-help.sh /usr/bin/docker-help
+COPY docker-help.sh /usr/local/bin/docker-help
 ENTRYPOINT ["docker-help"]

--- a/cp/Dockerfile
+++ b/cp/Dockerfile
@@ -1,0 +1,56 @@
+FROM solsson/kafka-jre@sha256:7765513cf5fa455a672a06f584058c1c81cc0b3b56cc56b0cfdf1a917a183f26
+
+ENV CP_VERSION=3.3.0
+
+WORKDIR /usr
+
+RUN set -ex; \
+  WORKDIR=$PWD; ls -l $WORKDIR/share/java; \
+  \
+  export DEBIAN_FRONTEND=noninteractive; \
+  runDeps=''; \
+  buildDeps='curl ca-certificates'; \
+  apt-get update && apt-get install -y $runDeps $buildDeps --no-install-recommends; \
+  \
+  MAVEN_VERSION=3.5.0 PATH=$PATH:/opt/maven/bin; \
+  mkdir -p /opt/maven; \
+  curl -SLs https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -xzf - --strip-components=1 -C /opt/maven; \
+  mvn --version; \
+  \
+  mkdir -p /opt/src/common; cd /opt/src/common; \
+  curl -SLs https://github.com/confluentinc/common/archive/v$CP_VERSION.tar.gz | tar -xzf - --strip-components=1 -C ./; \
+  mvn install; \
+  \
+  mkdir -p /opt/src/rest-utils; cd /opt/src/rest-utils; \
+  curl -SLs https://github.com/confluentinc/rest-utils/archive/v$CP_VERSION.tar.gz | tar -xzf - --strip-components=1 -C ./; \
+  mvn install; \
+  \
+  mkdir -p /opt/src/schema-registry; cd /opt/src/schema-registry; \
+  curl -SLs https://github.com/confluentinc/schema-registry/archive/v$CP_VERSION.tar.gz | tar -xzf - --strip-components=1 -C ./; \
+  mvn install; \
+  \
+  mkdir -p /opt/src/kafka-rest; cd /opt/src/kafka-rest; \
+  curl -SLs https://github.com/confluentinc/kafka-rest/archive/v$CP_VERSION.tar.gz | tar -xzf - --strip-components=1 -C ./; \
+  mvn install; \
+  \
+  cd $WORKDIR; \
+  \
+  mv /opt/src/common/package/target/common-package-$CP_VERSION-package/share/java/confluent-common ./share/java/; \
+  mv /opt/src/rest-utils/package/target/rest-utils-package-$CP_VERSION-package/share/java/rest-utils ./share/java/; \
+  \
+  mv /opt/src/schema-registry/package-schema-registry/target/kafka-schema-registry-package-$CP_VERSION-package/bin/* ./local/bin/; \
+  mv /opt/src/schema-registry/package-schema-registry/target/kafka-schema-registry-package-$CP_VERSION-package/share/java/* ./share/java/; \
+  mv /opt/src/schema-registry/package-schema-registry/target/kafka-schema-registry-package-$CP_VERSION-package/etc/* /etc/; \
+  \
+  mv /opt/src/kafka-rest/target/kafka-rest-$CP_VERSION-package/bin/* ./local/bin/; \
+  mv /opt/src/kafka-rest/target/kafka-rest-$CP_VERSION-package/share/java/* ./share/java/; \
+  mv /opt/src/kafka-rest/target/kafka-rest-$CP_VERSION-package/etc/* /etc; \
+  \
+  rm -Rf /opt/src /opt/maven /root/.m2; \
+  \
+  apt-get purge -y --auto-remove $buildDeps; \
+  rm -rf /var/lib/apt/lists/*; \
+  rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt
+
+COPY docker-help.sh /usr/bin/docker-help
+ENTRYPOINT ["docker-help"]

--- a/cp/Dockerfile
+++ b/cp/Dockerfile
@@ -2,10 +2,11 @@ FROM solsson/kafka-jre@sha256:7765513cf5fa455a672a06f584058c1c81cc0b3b56cc56b0cf
 
 ENV CP_VERSION=3.3.0
 
-WORKDIR /usr
+WORKDIR /usr/local
 
 RUN set -ex; \
-  WORKDIR=$PWD; ls -l $WORKDIR/share/java; \
+  WORKDIR=$PWD; \
+  mkdir -p $WORKDIR/share/java; \
   \
   export DEBIAN_FRONTEND=noninteractive; \
   runDeps=''; \
@@ -38,11 +39,11 @@ RUN set -ex; \
   mv /opt/src/common/package/target/common-package-$CP_VERSION-package/share/java/confluent-common ./share/java/; \
   mv /opt/src/rest-utils/package/target/rest-utils-package-$CP_VERSION-package/share/java/rest-utils ./share/java/; \
   \
-  mv /opt/src/schema-registry/package-schema-registry/target/kafka-schema-registry-package-$CP_VERSION-package/bin/* ./local/bin/; \
+  mv /opt/src/schema-registry/package-schema-registry/target/kafka-schema-registry-package-$CP_VERSION-package/bin/* ./bin/; \
   mv /opt/src/schema-registry/package-schema-registry/target/kafka-schema-registry-package-$CP_VERSION-package/share/java/* ./share/java/; \
   mv /opt/src/schema-registry/package-schema-registry/target/kafka-schema-registry-package-$CP_VERSION-package/etc/* /etc/; \
   \
-  mv /opt/src/kafka-rest/target/kafka-rest-$CP_VERSION-package/bin/* ./local/bin/; \
+  mv /opt/src/kafka-rest/target/kafka-rest-$CP_VERSION-package/bin/* ./bin/; \
   mv /opt/src/kafka-rest/target/kafka-rest-$CP_VERSION-package/share/java/* ./share/java/; \
   mv /opt/src/kafka-rest/target/kafka-rest-$CP_VERSION-package/etc/* /etc; \
   \

--- a/cp/docker-help.sh
+++ b/cp/docker-help.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "Hi,"
+echo ""
+echo "Select as entrypoint one of these scripts:"
+find ./local/bin/* -printf "%f\n"
+echo ""
+echo "You might find one of the sample config files useful:"
+find /etc/ -name *.properties
+echo ""

--- a/cp/docker-help.sh
+++ b/cp/docker-help.sh
@@ -2,7 +2,7 @@
 echo "Hi,"
 echo ""
 echo "Select as entrypoint one of these scripts:"
-find ./local/bin/* -printf "%f\n"
+find ./bin/* -printf "%f\n"
 echo ""
 echo "You might find one of the sample config files useful:"
 find /etc/ -name *.properties


### PR DESCRIPTION
[Schema Registry](https://github.com/confluentinc/schema-registry) and [REST Proxy](https://github.com/confluentinc/kafka-rest) have the same build steps and dependencies, and very similar startup scripts and config.

The concept with environment variables for config, used in [wurstmeister/kafka] and [https://hub.docker.com/r/confluentinc/](Confluent's) `cp-` images, is convenient for CLI docker and compose/swarm. In Kubernetes there's `ConfigMap` which means configuration can be edited directly without the need for local docker builds. With that we can use the distributed startup scripts directly, which I find more transparent. Also for evolving config it's easy to copy runtime config from container logs to the ConfigMap definition.