### PR TITLE
Try Kafka Connect GCS sink (proprietary)

### DIFF
--- a/connect-cp/Dockerfile
+++ b/connect-cp/Dockerfile
@@ -1,3 +1,13 @@
+FROM confluentinc/cp-kafka-connect:4.1.1 AS cp
+
+RUN curl -SLs https://s3-us-west-2.amazonaws.com/confluent-hub-client/confluent-hub-client-latest.tar.gz | tar -xzf - -C /usr
+
+RUN confluent-hub install --no-prompt --verbose confluentinc/kafka-connect-gcs:latest
+
+RUN find . -name kafka-connect*.jar
+
+RUN cat /usr/share/confluent-hub-components/confluentinc-kafka-connect-gcs/etc/quickstart-gcs.properties
+
 FROM solsson/kafka@sha256:7bd3e6f23a40cbd73f0e7e986c1d6bcf3f3892a5b73f2e3300ff844b0dd41ba8
 
 # referenced from dependency versions in the maven pom


### PR DESCRIPTION
https://www.confluent.io/connector/kafka-connect-gcs/ doesn't say anything about license.

https://docs.confluent.io/current/connect/kafka-connect-gcs/gcs_connector.html#installation works in docker, and we could copy to any image using `COPY --from=cp`. I wouldn't want to redistribute it though, because the `install` command says

```
Implicit acceptance of the license below:  
Confluent Software Evaluation License 
https://www.confluent.io/software-evaluation-license 
```

And the sample properties file says
```
# Confluent will issue a license key to each subscriber. The license key will be a short snippet
# of text that you can copy and paste. Without the license key, you can use this connector for a
# 30-day trial period. If you are a subscriber, please contact Confluent Support for more
# information.
#confluent.license=
```

I'll keep this PR as an example of how to run `confluent-hub` at docker build, because I found no such info in the docs.

I guess the proprietary nature of this means https://github.com/confluentinc/kafka-connect-storage-cloud/pull/127 and https://github.com/confluentinc/kafka-connect-storage-cloud/issues/128 will get zero attention.
