### PR TITLE
Kafka versions 2.0.0

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,7 +1,7 @@
 # The only assumption we make about this FROM is that it has a JRE in path
 FROM solsson/kafka-jre@sha256:06dabfc8cacd0687c8f52c52afd650444fb6d4a8e0b85f68557e6e7a5c71667c
 
-ENV KAFKA_VERSION=1.1.1 SCALA_VERSION=2.11
+ENV KAFKA_VERSION=2.0.0 SCALA_VERSION=2.11
 
 RUN set -ex; \
   export DEBIAN_FRONTEND=noninteractive; \


### PR DESCRIPTION
Update Kafka version to 2.0.0 as it includes this fix https://issues.apache.org/jira/browse/ZOOKEEPER-2184 which is really needed when running a cluster in docker/Kubernetes