### PR TITLE
Use Java 11 everywhere

### DIFF
--- a/initutils/Dockerfile
+++ b/initutils/Dockerfile
@@ -1,5 +1,5 @@
 # same FROM as kafka-jre, to keep pull times down and to provide the same shell distro+version
-FROM debian:stretch-slim@sha256:ea42520331a55094b90f6f6663211d4f5a62c5781673935fe17a4dfced777029
+FROM debian:9.6-slim@sha256:f05c05a218b7a4a5fe979045b1c8e2a9ec3524e5611ebfdd0ef5b8040f9008fa
 
 ENV KUBERNETES_VERSION=1.9.6 KUBERNETES_CLIENT_SHA256=2b1ab65171bcd43a099d4f7d05d7804c737272270e83f633e1c14ceed9a99133
 

--- a/initutils/Dockerfile
+++ b/initutils/Dockerfile
@@ -1,7 +1,7 @@
 # same FROM as kafka-jre, to keep pull times down and to provide the same shell distro+version
 FROM debian:9.6-slim@sha256:f05c05a218b7a4a5fe979045b1c8e2a9ec3524e5611ebfdd0ef5b8040f9008fa
 
-ENV KUBERNETES_VERSION=1.9.6 KUBERNETES_CLIENT_SHA256=2b1ab65171bcd43a099d4f7d05d7804c737272270e83f633e1c14ceed9a99133
+ENV KUBERNETES_VERSION=1.12.3 KUBERNETES_CLIENT_SHA256=4a3baa259869f3647f0b440effb04ce3455c1026ddac7e51b6692a0ee05eab1e
 
 RUN set -ex; \
   export DEBIAN_FRONTEND=noninteractive; \

--- a/kubectl-kafkacat/Dockerfile
+++ b/kubectl-kafkacat/Dockerfile
@@ -1,7 +1,6 @@
-# Select digest to have the same FROM as kafka-jre
 FROM solsson/kafkacat@sha256:be85344e8932d5dd4492fb37122be0bb9e65e560fe960058e0460ec13eea6547
 
-ENV KUBERNETES_VERSION=1.8.5 KUBERNETES_CLIENTS_SHA256=c32b6f90f1e8a15451f0d412d6d1f3db28948d2f7d76d4e28d83c11e1eb25f20
+ENV KUBERNETES_VERSION=1.12.3 KUBERNETES_CLIENT_SHA256=4a3baa259869f3647f0b440effb04ce3455c1026ddac7e51b6692a0ee05eab1e
 
 RUN set -ex; \
   export DEBIAN_FRONTEND=noninteractive; \
@@ -11,7 +10,7 @@ RUN set -ex; \
   rm -rf /var/lib/apt/lists/*; \
   \
   curl -sLS -o k.tar.gz -k https://dl.k8s.io/v${KUBERNETES_VERSION}/kubernetes-client-linux-amd64.tar.gz; \
-  echo "$KUBERNETES_CLIENTS_SHA256  k.tar.gz" | sha256sum -c; \
+  echo "$KUBERNETES_CLIENT_SHA256  k.tar.gz" | sha256sum -c; \
   tar -xvzf k.tar.gz -C /usr/local/bin/ --strip-components=3 kubernetes/client/bin/kubectl; \
   rm k.tar.gz; \
   \

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM solsson/jdk-opensource:11.0.1@sha256:740feb6c1ecbdf2beac1dc41405c3215511b90d83a7211f805e88f92946dd2a9
+FROM solsson/kafka-jre:8@sha256:1ebc3c27c30f5925d240aaa0858e111c2fa6d358048b0f488860ea9cd9c84822
 
 ENV KAFKA_MANAGER_VERSION=1.3.3.18
 

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM solsson/kafka-jre:8@sha256:1ebc3c27c30f5925d240aaa0858e111c2fa6d358048b0f488860ea9cd9c84822
+FROM solsson/jdk-opensource:11.0.1@sha256:740feb6c1ecbdf2beac1dc41405c3215511b90d83a7211f805e88f92946dd2a9
 
 ENV KAFKA_MANAGER_VERSION=1.3.3.18
 

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM solsson/kafka-jre:8@sha256:1ebc3c27c30f5925d240aaa0858e111c2fa6d358048b0f488860ea9cd9c84822
+FROM solsson/jdk-opensource:11.0.1@sha256:740feb6c1ecbdf2beac1dc41405c3215511b90d83a7211f805e88f92946dd2a9
 
 ENV KAFKA_MONITOR_REPO=https://github.com/linkedin/kafka-monitor \
     KAFKA_MONITOR_VERSION=2.0.0 \

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -11,9 +11,9 @@ RUN set -ex; \
   apt-get update && apt-get install -y $runDeps $buildDeps --no-install-recommends; \
   \
   cd /opt; \
-  GRADLE_VERSION=4.3.1 PATH=$PATH:$(pwd)/gradle-$GRADLE_VERSION/bin; \
+  GRADLE_VERSION=4.10.2 PATH=$PATH:$(pwd)/gradle-$GRADLE_VERSION/bin; \
   curl -SLs -o gradle-$GRADLE_VERSION-bin.zip https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip; \
-  echo "15ebe098ce0392a2d06d252bff24143cc88c4e963346582c8d88814758d93ac7  gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -; \
+  echo "b49c6da1b2cb67a0caf6c7480630b51c70a11ca2016ff2f555eaeda863143a29  gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -; \
   unzip gradle-$GRADLE_VERSION-bin.zip; \
   rm gradle-$GRADLE_VERSION-bin.zip; \
   gradle -v; \
@@ -25,7 +25,8 @@ RUN set -ex; \
   rm monitor.tar.gz; \
   \
   cd /opt/kafka-monitor; \
-  ./gradlew jar; \
+  rm gradlew; \
+  gradle --no-daemon jar; \
   \
   sed -i 's/localhost:2181/zookeeper:2181/' config/kafka-monitor.properties; \
   sed -i 's/localhost:9092/bootstrap:9092/' config/kafka-monitor.properties; \

--- a/prometheus-jmx-exporter/Dockerfile
+++ b/prometheus-jmx-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM solsson/kafka-jre:8@sha256:1ebc3c27c30f5925d240aaa0858e111c2fa6d358048b0f488860ea9cd9c84822
+FROM solsson/jdk-opensource:11.0.1@sha256:740feb6c1ecbdf2beac1dc41405c3215511b90d83a7211f805e88f92946dd2a9
 
 ENV EXPORTER_VERSION=parent-0.3.1
 ENV EXPORTER_REPO=github.com/prometheus/jmx_exporter


### PR DESCRIPTION
Java 10 came with support for docker memory limits by default, see https://blog.docker.com/2018/04/improved-docker-container-integration-with-java-10/, but wasn't LTS. Kafka 2.1.0 supports Java 11.