### PR TITLE
WIP seems to copy a topic to itself - endless loop indeed

### DIFF
--- a/mirrormaker-topic-rename/Dockerfile
+++ b/mirrormaker-topic-rename/Dockerfile
@@ -1,0 +1,20 @@
+FROM maven:3.6.0-jdk-11-slim@sha256:88df28c7aa219fdd7863596791d3301a8ffd996f5985ac6f9ae1e1a738027377
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl ca-certificates git
+
+RUN git clone https://github.com/opencore/mirrormaker_topic_rename
+WORKDIR /mirrormaker_topic_rename/
+
+COPY pom.xml .
+RUN mvn package
+
+FROM solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
+
+COPY --from=0 /mirrormaker_topic_rename/target/mmchangetopic-1.0-SNAPSHOT.jar /opt/kafka/libs/extensions/
+
+# https://github.com/opencore/mirrormaker_topic_rename#usage
+# https://github.com/Yolean/kubernetes-kafka/blob/v5.1.0/kafka/50kafka.yml#L51
+ENV CLASSPATH=/opt/kafka/libs/extensions/mmchangetopic-1.0-SNAPSHOT.jar
+
+ENTRYPOINT [ "./bin/kafka-mirror-maker.sh" ]

--- a/mirrormaker-topic-rename/README.md
+++ b/mirrormaker-topic-rename/README.md
@@ -1,0 +1,1 @@
+https://www.opencore.com/blog/2017/1/170131-mirrormaker-change-topic/

--- a/mirrormaker-topic-rename/pom.xml
+++ b/mirrormaker-topic-rename/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.opencore</groupId>
+  <artifactId>mmchangetopic</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>mmchangetopic</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.12</artifactId>
+      <version>2.1.1</version>
+    </dependency>
+  </dependencies>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+</project>


### PR DESCRIPTION
I tested this as alternative to https://github.com/Yolean/kafka-topics-copy/pull/1 but I will abort the experiment because:

- Small config mistakes can lead to a topic being copied to itself.
- Mirrormaker in its current form looks dateda anyway: https://cwiki.apache.org/confluence/display/KAFKA/KIP-382%3A+MirrorMaker+2.0