### PR TITLE
downgrade to openjdk:8u212 to fix build issue with Java>8

### DIFF
--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM solsson/jdk-opensource:11.0.2@sha256:9088fd8eff0920f6012e422cdcb67a590b2a6edbeae1ff0ca8e213e0d4260cf8
+FROM openjdk:8u212-jdk-slim-stretch
 
 ENV KAFKA_MANAGER_VERSION=1.3.3.23
 


### PR DESCRIPTION
By downgrading the jdk to 8u212 I was able to build the latest version of kafka-manager.