### PR TITLE
Dynamic java heap settings for cruise-control

### DIFF
--- a/cruise-control/opt/cruise-control/start.sh
+++ b/cruise-control/opt/cruise-control/start.sh
@@ -2,7 +2,8 @@
 set -e
 cd /opt/cruise-control
 
-# Override heap settings for container environments
-export KAFKA_HEAP_OPTS="-XX:InitialRAMPercentage=30 -XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=80"
-
+# Set heap memory settings for container environments
+if [ -z "$KAFKA_HEAP_OPTS" ]; then
+  export KAFKA_HEAP_OPTS="-XX:InitialRAMPercentage=30 -XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=80"
+fi
 /bin/bash ${DEBUG:+-x} /opt/cruise-control/kafka-cruise-control-start.sh /opt/cruise-control/config/cruisecontrol.properties 8090

--- a/cruise-control/opt/cruise-control/start.sh
+++ b/cruise-control/opt/cruise-control/start.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 set -e
 cd /opt/cruise-control
+
+# Override heap settings for container environments
+export KAFKA_HEAP_OPTS="-XX:InitialRAMPercentage=30 -XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=80"
+
 /bin/bash ${DEBUG:+-x} /opt/cruise-control/kafka-cruise-control-start.sh /opt/cruise-control/config/cruisecontrol.properties 8090


### PR DESCRIPTION
Configure CruiseControl Java heap sizes using container available memory ratios.
This is available in Java11 introduced in 
(https://github.com/solsson/dockerfiles/commit/c6cfc1cdd3051a4bc8e3a0eb635099e8b32a3ed0#diff-25116d53120aac394f7afcbad1211369)

Using these settings allows the tuning of actual heap size of the CC JVM using docker container limits and not [statically 1GB](https://github.com/linkedin/cruise-control/blob/9828a9bdb070a7c9460bad2b75fb7be3e963a733/kafka-cruise-control-start.sh#L131)