### PR TITLE
Sort entries in docker help so they are printed in alphabetical order

### DIFF
--- a/cp/docker-help.sh
+++ b/cp/docker-help.sh
@@ -2,8 +2,8 @@
 echo "Hi,"
 echo ""
 echo "Select as entrypoint one of these scripts:"
-find ./bin/* -printf "%f\n"
+find ./bin/* -printf "%f\n" | sort
 echo ""
 echo "You might find one of the sample config files useful:"
-find /etc/ -name *.properties
+find /etc/ -name *.properties | sort
 echo ""

--- a/kafka/docker-help.sh
+++ b/kafka/docker-help.sh
@@ -5,10 +5,10 @@ echo "This image is basically just the official Kafka distribution,"
 echo "containing both servers and utils, each with its own help output."
 echo ""
 echo "Select as entrypoint one of these scripts:"
-find ./bin/ -name *.sh
+find ./bin/ -name *.sh | sort
 echo ""
 echo "You might find one of the sample config files useful:"
-find ./config/ -name *.properties
+find ./config/ -name *.properties | sort
 echo ""
 echo "Add more using volumes, or downstream images."
 echo "Enjoy Kafka!"


### PR DESCRIPTION
I noticed that the order of entries printed from docker-help can be unpredictable. This change ensures that the entries are printed in alphabetical order which makes them easier to scan.